### PR TITLE
Add support for some block devices in /dev under Linux

### DIFF
--- a/pmonitor.sh
+++ b/pmonitor.sh
@@ -52,8 +52,13 @@ display()
     # Return length of specified file
     function file_length(fname) {
       if (!cached_length[fname]) {
-	"ls -l '\''" fname "'\'' 2>/dev/null" | getline
-	cached_length[fname] = $5 + 0
+        if (fname ~ /^\/dev\/[^/]*$/ && system("test -b " fname) == 0) {
+          getline < ("/sys/block/" substr(fname, 6) "/size")
+          cached_length[fname] = $1 * 512 # sector size is always 512 bytes
+        } else {
+          "ls -l '\''" fname "'\'' 2>/dev/null" | getline
+          cached_length[fname] = $5 + 0
+        }
       }
       return cached_length[fname]
     }


### PR DESCRIPTION
There appears to be no generic cross-platform way to determine the size of a block device, but if we’re running on Linux, we can discover the size of some of them from [**sysfs**(5)](https://manpages.debian.org/stretch/manpages-dev/sysfs.2.en.html). This assumes that devices are placed under their normal names under `/dev` (no subdirectories, since we need the normal basename for the sysfs path) and that sysfs is mounted under its usual location.

The format of /sys/block/*/size does not seem to be documented anywhere, but the size is always in 512-byte sectors (not device-specific blocks) according to the comments on [a Unix & Linux StackExchange answer][1].

Fixes #1.

[1]: https://unix.stackexchange.com/a/52219/44049