### PR TITLE
Don’t print trailing space if ETA is missing

### DIFF
--- a/pmonitor.sh
+++ b/pmonitor.sh
@@ -86,9 +86,9 @@ display()
 	  eta_m = t % 60
 	  t = int(t / 60)
 	  eta_h = t
-	  eta = sprintf("ETA %d:%02d:%02d", eta_h, eta_m, eta_s)
+	  eta = sprintf(" ETA %d:%02d:%02d", eta_h, eta_m, eta_s)
 	}
-        print fname, offset / len * 100 "%", eta
+        print fname, offset / len * 100 "%" eta
       }
     }
   '


### PR DESCRIPTION
Instead of printing the percentage and the ETA separated by a space, even if the ETA is absent (undefined variable = empty string), prepend a space to the ETA and concatenate them directly, so that there is no trailing space if the ETA could not be determined yet.

Fixes #3, where the trailing space confused `test-pmonitor.sh`.