### PR TITLE
Escape slash inside bracket expression

### DIFF
--- a/pmonitor.sh
+++ b/pmonitor.sh
@@ -52,7 +52,7 @@ display()
     # Return length of specified file
     function file_length(fname) {
       if (!cached_length[fname]) {
-        if (fname ~ /^\/dev\/[^/]*$/ && system("test -b " fname) == 0) {
+        if (fname ~ /^\/dev\/[^\/]*$/ && system("test -b " fname) == 0) {
           getline < ("/sys/block/" substr(fname, 6) "/size")
           cached_length[fname] = $1 * 512 # sector size is always 512 bytes
         } else {


### PR DESCRIPTION
Many AWK implementations appears to allow unescaped slashes inside a bracket expression in a regular expression literal, consistent with the way that most metacharacters lose their meaning inside bracket expressions (tested: GNU Awk 4.2.1, mawk 1.3.4, and BWK awk (nawk) 20121220, all on Arch Linux); however, some versions also appear to require such a slash to be escaped (tested: mawk 1.3.3 on Debian Stretch), and this appears to be consistent with POSIX, which in the Lexical Conventions, number 6, states that “[a]n ERE constant shall be terminated by the first unescaped occurrence of the <slash> character after the one that begins the ERE constant.” Escaping the slash appears to be safe in all tested versions (that is, it does not count the backslash as part of the bracket expression), so let’s do that to ensure the program also works with mawk 1.3.3 on Debian Stretch, fixing #7.