### PR TITLE
Close command used to determine file size

### DIFF
--- a/pmonitor.sh
+++ b/pmonitor.sh
@@ -56,7 +56,9 @@ display()
           getline < ("/sys/block/" substr(fname, 6) "/size")
           cached_length[fname] = $1 * 512 # sector size is always 512 bytes
         } else {
-          "ls -l '\''" fname "'\'' 2>/dev/null" | getline
+          lscmd = "ls -l '\''" fname "'\'' 2>/dev/null"
+          lscmd | getline
+          close(lscmd)
           cached_length[fname] = $5 + 0
         }
       }


### PR DESCRIPTION
When an AWK program reads from a file or process, AWK keeps the connection to the file or process open until the program explicitly closes it. This is useful in order to read multiple lines from a file, or to keep reading input from a long-running coprocess, but it also means that we must make sure to close any short helper program we launch, otherwise we will leak one file descriptor (the pipe to the child process) per invocation and eventually run out of file descriptors (`EMFILE` Too many open files). (See also the `time()` function for an example where we already do this.)

Fixes #9.