### PR TITLE
Fix test

### DIFF
--- a/test-pmonitor.sh
+++ b/test-pmonitor.sh
@@ -13,7 +13,7 @@ PID=$!
 
 sleep 1
 
-RESULT=$(./pmonitor.sh -p $PID | sed -n '/dict/s/.* \(.*\)\.[0-9][0-9]%/\1/p')
+RESULT=$(./pmonitor.sh -p $PID | sed -n '/dict/s/.*\t\(.*\)\.[0-9][0-9]%/\1/p')
 
 wait
 


### PR DESCRIPTION
pmonitor separates file name and percentage by a tab, not by a space.

---

I don’t really understand what’s going on here. As far as I can see from the git log, this should always have been a tab, and I couldn’t find a working state for this test with `git bisect` – but at the same time, I’m pretty sure I remember successfully running these tests before…